### PR TITLE
Removed Google Analytics placeholder and empty GTAG setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,6 @@ VITE_AUTH0_AUDIENCE=http://localhost:4040# Replace with your actual audience URL
 VITE_MAPPERS_API_SERVER=<update - this is your php backend>
 VITE_MAPPERS_API_KEY=<update - this is your php backend key in settings.php> # Replace with your actual API key from settings.php
 
-# Google Tag Manager configuration
-VITE_GTAG_ID="" # Google Tag Manager ID, leave empty if not using Google Analytics
-
 #Open Graph configuration
 VITE_OG_TITLE="Site Title"
 VITE_OG_DESCRIPTION="Site Description"

--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
       content="Come map other worlds."
     />
 
-      <!-- Google Analytics -->
-      <script async
-              src="https://www.googletagmanager.com/gtag/js?id=%VITE_GTAG_ID%"></script>
       <script>
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
This pull request removes the Google Analytics (Google Tag Manager) placeholder.

Motivation:
- For a scientific open source project, including Google Analytics is not strictly necessary and may raise privacy concerns, as it involves tracking users externally.  
- Any analytics that the team needs can be effectively collected via server-side logs, which respect user privacy while providing the necessary usage data.  
- In this project, the GA setup was never active (no ID configured) — it was just a placeholder, serving no functional purpose and needlessly loading external scripts, consuming users' network resources.  

Changes:
- [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL14-L16): Removed the empty `VITE_GTAG_ID` variable and associated comments.
- [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L18-L20): Removed the script tag that would load Google Analytics.